### PR TITLE
Fixing a bug in the DataFactory

### DIFF
--- a/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
+++ b/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
@@ -48,11 +48,29 @@ import org.fluttercode.datafactory.NameDataValues;
  */
 public final class DataFactory {
 
-  private static Random random = new Random(System.currentTimeMillis());
+  private Random random;
 
 	private NameDataValues nameDataValues = new DefaultNameDataValues();
 	private AddressDataValues addressDataValues = new DefaultAddressDataValues();
 	private ContentDataValues contentDataValues = new DefaultContentDataValues();
+
+
+  /**
+   * Constructor that takes a seed for the internal random generator
+   * @param randomSeed The seed to initialize the internal random generator with.
+   */
+  public DataFactory(long randomSeed) {
+    random = new Random(randomSeed);
+  }
+
+  /**
+   * Default constructor, initializes the random generator with the same value
+   * every time.  The reasoning behind this is to support generating the same
+   * sequence of 'random' data in different test runs.
+   */
+  public DataFactory() {
+    this(93285l);
+  }
 
 	/**
 	 * Returns a random item from a list of items.


### PR DESCRIPTION
This patch is to fix a bug where the random number generator used by the DataFactory was seeded with a static value, leading to the exact same sequence of 'random' data being generated each time my tests were run.  It is now seeded with the current system time in miliseconds.
