### PR TITLE
DataFactory.getRandomText() now produces text with spaces & words

### DIFF
--- a/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
+++ b/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
@@ -415,7 +415,9 @@ public final class DataFactory {
 				sb.append(" ");
 				length--;
 			}
-			String word = getRandomWord(length);
+            final double desiredWordLength = Math.abs(1.0+random.nextGaussian() * 6);
+            int usedWordLength = (int)(Math.min(length, desiredWordLength));
+			String word = getRandomWord(usedWordLength);
 			sb.append(word);
 			length = length - word.length();
 		}

--- a/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
+++ b/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
@@ -415,8 +415,8 @@ public final class DataFactory {
 				sb.append(" ");
 				length--;
 			}
-            final double desiredWordLength = Math.abs(1.0+random.nextGaussian() * 6);
-            int usedWordLength = (int)(Math.min(length, desiredWordLength));
+			final double desiredWordLengthNormalDistributed = Math.abs(1.0+random.nextGaussian() * 6);
+			int usedWordLength = (int)(Math.min(length, desiredWordLengthNormalDistributed));
 			String word = getRandomWord(usedWordLength);
 			sb.append(word);
 			length = length - word.length();

--- a/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
+++ b/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
@@ -415,7 +415,7 @@ public final class DataFactory {
 				sb.append(" ");
 				length--;
 			}
-			final double desiredWordLengthNormalDistributed = Math.abs(1.0+random.nextGaussian() * 6);
+			final double desiredWordLengthNormalDistributed = 1.0+Math.abs(random.nextGaussian()) * 6;
 			int usedWordLength = (int)(Math.min(length, desiredWordLengthNormalDistributed));
 			String word = getRandomWord(usedWordLength);
 			sb.append(word);

--- a/src/test/java/org/fluttercode/datafactory/impl/DataFactoryTextTest.java
+++ b/src/test/java/org/fluttercode/datafactory/impl/DataFactoryTextTest.java
@@ -56,7 +56,9 @@ public class DataFactoryTextTest {
 					text.length(), len, text), len == text.length());
 
 		}
-	}@Test
+	}
+
+    @Test
 	public void shouldReturnTextWithWords() {
 		for (int i = 0; i < ITERATION_COUNT; i++) {
 			int len = 512 + dataFactory.getNumberUpTo(128);

--- a/src/test/java/org/fluttercode/datafactory/impl/DataFactoryTextTest.java
+++ b/src/test/java/org/fluttercode/datafactory/impl/DataFactoryTextTest.java
@@ -56,6 +56,18 @@ public class DataFactoryTextTest {
 					text.length(), len, text), len == text.length());
 
 		}
+	}@Test
+	public void shouldReturnTextWithWords() {
+		for (int i = 0; i < ITERATION_COUNT; i++) {
+			int len = 512 + dataFactory.getNumberUpTo(128);
+			String text = dataFactory.getRandomText(len);
+			Assert.assertTrue(String.format(
+					"Length does not match (%d, expected %d) '%s' ",
+					text.length(), len, text), len == text.length());
+            String[] words =   text.split(" ");
+            Assert.assertTrue("long texts should contain spaces",words.length>32);
+
+		}
 	}
 
 	@Test

--- a/src/test/java/org/fluttercode/datafactory/impl/DataFactoryTextTest.java
+++ b/src/test/java/org/fluttercode/datafactory/impl/DataFactoryTextTest.java
@@ -68,6 +68,7 @@ public class DataFactoryTextTest {
 					text.length(), len, text), len == text.length());
             String[] words =   text.split(" ");
             Assert.assertTrue("long texts should contain spaces",words.length>32);
+            Assert.assertFalse("text should not contain double spaces",text.contains("  "));
 
 		}
 	}


### PR DESCRIPTION
Hi

Thanks for this small library.

So far DataFactory.getRandomText produces a giant, single word for a longer text. Is that by design? 

I changed it so that it produces a text consisting of words and spaces. 

If you want that behavior in a separate method, or more tests etc I'll do it.

Cheers

Roman