### PR TITLE
fixed generating random numbers

### DIFF
--- a/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
+++ b/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
@@ -317,7 +317,7 @@ public final class DataFactory {
 					max));
 		}
 
-		return min + random.nextInt(max - min);
+		return min + random.nextInt(Math.abs(max - min));
 	}
 
 	/**

--- a/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
+++ b/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
@@ -23,6 +23,7 @@ package org.fluttercode.datafactory.impl;
  *
  */
 
+import java.math.BigInteger;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -317,7 +318,39 @@ public final class DataFactory {
 					max));
 		}
 
-		return min + random.nextInt(Math.abs(max - min));
+		int average = avg(min, max);
+		int base = abs(min - average);
+
+		int randomNumber;
+		if (base != 0) {
+			randomNumber = random.nextInt(base);
+		} else {
+			randomNumber = 0;
+		}
+
+		if (random.nextBoolean()) {
+			return average + randomNumber;
+		} else {
+			return average - randomNumber;
+		}
+	}
+
+	private int abs(int number) {
+		if (number == Integer.MIN_VALUE) {
+			// -1 * MIN_VALUE will overflow
+			return Integer.MAX_VALUE;
+		} else {
+			return Math.abs(number);
+		}
+	}
+
+	private int avg(int first, int second) {
+		BigInteger firstInt = BigInteger.valueOf(first);
+		BigInteger secondInt = BigInteger.valueOf(second);
+		
+		return firstInt.add(secondInt).
+				divide(BigInteger.valueOf(2)).
+				intValue();
 	}
 
 	/**

--- a/src/test/java/org/fluttercode/datafactory/impl/DataFactoryTextTest.java
+++ b/src/test/java/org/fluttercode/datafactory/impl/DataFactoryTextTest.java
@@ -97,6 +97,24 @@ public class DataFactoryTextTest {
 		dataFactory.getNumber();
 	}
 	
+	@Test
+	public void shouldReturnNegativeNumber() {
+		int random = dataFactory.getNumberBetween(Integer.MIN_VALUE, -1);
+		Assert.assertTrue(random < 0);
+	}
+
+	@Test
+	public void shouldReturnMinValue() {
+		int random = dataFactory.getNumberBetween(Integer.MIN_VALUE, Integer.MIN_VALUE);
+		Assert.assertEquals(Integer.MIN_VALUE, random);
+	}
+
+	@Test
+	public void shouldReturnMaxValue() {
+		int random = dataFactory.getNumberBetween(Integer.MAX_VALUE, Integer.MAX_VALUE);
+		Assert.assertEquals(Integer.MAX_VALUE, random);
+	}
+
 	//Test param checking on randomWord()
 	
 	@Test(expected=IllegalArgumentException.class)

--- a/src/test/java/org/fluttercode/datafactory/impl/DataFactoryTextTest.java
+++ b/src/test/java/org/fluttercode/datafactory/impl/DataFactoryTextTest.java
@@ -92,6 +92,11 @@ public class DataFactoryTextTest {
 
 	}
 
+	@Test
+	public void shouldReturnRandomNumber() {
+		dataFactory.getNumber();
+	}
+	
 	//Test param checking on randomWord()
 	
 	@Test(expected=IllegalArgumentException.class)


### PR DESCRIPTION
For instance, DataFactory#getNumber() method throws IllegalArgumentException: n must be positive, so this commit passes absolute values of argument substraction.

Stack trace:

java.lang.IllegalArgumentException: n must be positive
	at java.util.Random.nextInt(Random.java:300)
	at org.fluttercode.datafactory.impl.DataFactory.getNumberBetween(DataFactory.java:320)
	at org.fluttercode.datafactory.impl.DataFactory.getNumber(DataFactory.java:289)