### PR TITLE
Allow words with random length in random text

### DIFF
--- a/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
+++ b/src/main/java/org/fluttercode/datafactory/impl/DataFactory.java
@@ -415,7 +415,7 @@ public final class DataFactory {
 				sb.append(" ");
 				length--;
 			}
-			String word = getRandomWord(length);
+			String word = getRandomWord(0, length);
 			sb.append(word);
 			length = length - word.length();
 		}


### PR DESCRIPTION
Fixes #8 by allowing a word min-length of `0` when generating random text