### PR TITLE
Remove space included in default words

### DIFF
--- a/src/main/java/org/fluttercode/datafactory/impl/DefaultContentDataValues.java
+++ b/src/main/java/org/fluttercode/datafactory/impl/DefaultContentDataValues.java
@@ -45,7 +45,7 @@ public class DefaultContentDataValues implements ContentDataValues {
 			"magnetic", "pull", "shepherd", "always", "wrong", "much",
 			"suspense", "what", "to", "do", "when", "it", "ends", "I", "will",
 			"have", "to", "find", "something", "else", "to", "pique", "my",
-			"interest", "or maybe", "write", "lots", "of", "code", "probably",
+			"interest", "maybe", "write", "lots", "of", "code", "probably",
 			"should", "have", "generated", "this", "text", "automatically",
 			"so", "will", "from", "the", "web", "ending", "badly", "library",
 			"handled", "books", "constantly", "headphones", "of", "ill", "on",


### PR DESCRIPTION
This prevents invalid email addresses from being generated.
